### PR TITLE
For matching latest poppler version.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -26,11 +26,13 @@ pkgbase = openboard
 	source = openboard.desktop
 	source = qchar.patch
 	source = quazip.patch
+	source = c++17.patch
 	source = drop_ThirdParty_repo.patch
 	sha256sums = cf5bfb570b9ac4e61e1670c5a433f1dcaf0de1e8dbcbd544f058711690afba79
 	sha256sums = 64289f9d91cb25fa79fb988f19d43a542d67380fcf27668d0da1ee4ba1e705eb
 	sha256sums = b40fdab85f5921d0404c07db64628a2428a87d39193d2797bbef2e69b1d51549
-	sha256sums = 0a9d037336dab3dbd99652b71934a94cd1e9801650fe5e72f4dd1de1718dd4c1
+	sha256sums = 177559f359b0a6d7e407fc9c44dedfab2d492b5cc9334e1d763b16fdf2efc683
+	sha256sums = 7b3ca090cee096f47b27f29f2a1a956b4afcaa08338a084fcb20cd7f01d71e26
 	sha256sums = a6a9bc1f9c9bee0345b735fcf422245ae7946f96f6c34520dd63530a98978c14
 
 pkgname = openboard

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -16,11 +16,13 @@ source=("https://github.com/OpenBoard-org/OpenBoard/archive/v${pkgver}.tar.gz"
         openboard.desktop)
 source+=(qchar.patch)
 source+=(quazip.patch)
+source+=(c++17.patch)
 source+=(drop_ThirdParty_repo.patch)
 sha256sums=('cf5bfb570b9ac4e61e1670c5a433f1dcaf0de1e8dbcbd544f058711690afba79'
             '64289f9d91cb25fa79fb988f19d43a542d67380fcf27668d0da1ee4ba1e705eb'
             'b40fdab85f5921d0404c07db64628a2428a87d39193d2797bbef2e69b1d51549'
-            '0a9d037336dab3dbd99652b71934a94cd1e9801650fe5e72f4dd1de1718dd4c1'
+            '177559f359b0a6d7e407fc9c44dedfab2d492b5cc9334e1d763b16fdf2efc683'
+            '7b3ca090cee096f47b27f29f2a1a956b4afcaa08338a084fcb20cd7f01d71e26'
             'a6a9bc1f9c9bee0345b735fcf422245ae7946f96f6c34520dd63530a98978c14')
 
 prepare() {
@@ -31,6 +33,8 @@ prepare() {
   patch -p1 < "$srcdir"/qchar.patch
   msg2 "quazip"
   patch -f -p1 < "$srcdir"/quazip.patch
+  msg2 "cpp17"
+  patch -f -p1 < "$srcdir"/c++17.patch
   msg2 "gcc11"
   sed 's/_serialize/serialize/g' -i src/pdf-merger/Object.{h,cpp}
 }

--- a/c++17.patch
+++ b/c++17.patch
@@ -1,0 +1,16 @@
+--- orig/OpenBoard.pro	2022-01-17 19:21:33.000000000 +0100
++++ OpenBoard-1.6.1/OpenBoard.pro	2022-01-13 20:52:35.000000000 +0100
+@@ -1,11 +1,12 @@
+ TARGET = "OpenBoard"
+ TEMPLATE = app
+ 
+-CONFIG += c++14
++CONFIG += c++1z
+ CONFIG -= flat
+ CONFIG += debug_and_release \
+           no_include_pwd
+ 
++QMAKE_CXXFLAGS += -std=c++17
+ 
+ VERSION_MAJ = 1
+ VERSION_MIN = 6

--- a/quazip.patch
+++ b/quazip.patch
@@ -1,7 +1,6 @@
-diff -Naur OpenBoard-1.6.0a3.orig/OpenBoard.pro OpenBoard-1.6.0a3/OpenBoard.pro
---- OpenBoard-1.6.0a3.orig/OpenBoard.pro	2020-05-22 18:40:49.000000000 +0200
-+++ OpenBoard-1.6.0a3/OpenBoard.pro	2020-10-12 07:26:16.628748656 +0200
-@@ -433,8 +431,8 @@
+--- orig/OpenBoard.pro	2022-01-17 19:21:33.000000000 +0100
++++ OpenBoard-1.6.1/OpenBoard.pro	2022-01-13 20:52:35.000000000 +0100
+@@ -450,8 +451,8 @@
      LIBS += -lcrypto
      #LIBS += -lprofiler
      LIBS += -lX11
@@ -12,7 +11,6 @@ diff -Naur OpenBoard-1.6.0a3.orig/OpenBoard.pro OpenBoard-1.6.0a3/OpenBoard.pro
  
      LIBS += -lpoppler
      INCLUDEPATH += "/usr/include/poppler"
-diff -Naur OpenBoard-1.6.0a3.orig/plugins/cffadaptor/UBCFFAdaptor.pro OpenBoard-1.6.0a3/plugins/cffadaptor/UBCFFAdaptor.pro
 --- OpenBoard-1.6.0a3.orig/plugins/cffadaptor/UBCFFAdaptor.pro	2020-05-22 18:40:49.000000000 +0200
 +++ OpenBoard-1.6.0a3/plugins/cffadaptor/UBCFFAdaptor.pro	2020-10-12 07:20:08.496096917 +0200
 @@ -13,9 +13,6 @@


### PR DESCRIPTION
This Pull Request has the patches for compiling OpenBoard with c++17 and match the requirements of the latest poppler version in Arch Linux.